### PR TITLE
Filter page on php side and reverse array

### DIFF
--- a/pico_rss/pico_rss.php
+++ b/pico_rss/pico_rss.php
@@ -28,7 +28,7 @@ class Pico_Rss {
 	public function get_pages(&$pages, &$current_page, &$prev_page, &$next_page)
 	{
 		// Limit feed to latest 10 posts
-		if($this->is_feed) $pages = array_slice($pages, 0, 10);
+		if($this->is_feed) $pages = array_slice(array_reverse(array_filter($pages, function($p) {return $p['date'];})), 0, 10);
 	}
 	
 	public function before_render(&$twig_vars, &$twig)

--- a/pico_rss/rss.html
+++ b/pico_rss/rss.html
@@ -6,7 +6,6 @@
 		<description>RSS feed for {{ site_title }}</description>
 		<atom:link href="{{ base_url }}/feed" rel="self" type="application/rss+xml" />
 		{% for page in pages %}
-			{% if page.date %}
 			<item>
 				<title>{{ page.title }}</title>
 				<description><![CDATA[{{ page.content }}]]></description>
@@ -14,7 +13,6 @@
 				<pubDate>{{ page.date|date("D, d M Y H:i:s O") }}</pubDate>
 				<guid>{{ page.url }}</guid>
 			</item>
-			{% endif %}
 		{% endfor %}
 	</channel>
 </rss>


### PR DESCRIPTION
Hi,

Thanks for your plugin, but it does not work well in my case : pages + blog : the php side keeps the 10 "first" pages which includes pages that are not blog posts and then are filtered in the template.

I've reversed the array and kept only the 10 first pages which have a date to fix this issue